### PR TITLE
Add ability to filter output JSON fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,128 @@
-dist/
-python_logging_rabbitmq.egg-info/
+## Python
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
 build/
-.idea/
-*.pyc
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+env2/
+env3/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+## Vim
+
+.dir-locals.el# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-v][a-z]
+[._]sw[a-p]
+
+# Session
+*.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+
+## Mac
 .DS_Store

--- a/python_logging_rabbitmq/compat.py
+++ b/python_logging_rabbitmq/compat.py
@@ -2,7 +2,6 @@
 # Thanks to https://github.com/lobziik/rlog
 import sys
 
-
 if sys.version_info[0] == 2:
     text_type = unicode
     from Queue import Queue as Queue

--- a/python_logging_rabbitmq/filters.py
+++ b/python_logging_rabbitmq/filters.py
@@ -6,7 +6,6 @@ class FieldFilter(logging.Filter):
     Filter to add extra fields before log the record.
     @alternative: https://docs.python.org/2/library/logging.html#loggeradapter-objects
     """
-
     def __init__(self, fields, fields_under_root):
         super(FieldFilter, self).__init__()
 

--- a/python_logging_rabbitmq/formatters.py
+++ b/python_logging_rabbitmq/formatters.py
@@ -10,6 +10,13 @@ class JSONFormatter(logging.Formatter):
     Formatter to convert LogRecord into JSON.
     Thanks to: https://github.com/lobziik/rlog
     """
+    def __init__(self, *args, **kwargs):
+        include = kwargs.pop('include', None)
+        exclude = kwargs.pop('exclude', None)
+        super().__init__(*args, **kwargs)
+        self.include = include
+        self.exclude = exclude
+
     def format(self, record):
         data = record.__dict__.copy()
 
@@ -26,5 +33,11 @@ class JSONFormatter(logging.Formatter):
 
         if 'exc_info' in data and data['exc_info']:
             data['exc_info'] = self.formatException(data['exc_info'])
+
+        if self.include:
+            data = {f: data[f] for f in self.include}
+        elif self.exclude:
+            for f in self.exclude:
+               del data[f]
 
         return json.dumps(data)

--- a/python_logging_rabbitmq/formatters.py
+++ b/python_logging_rabbitmq/formatters.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 import logging
 from socket import gethostname
-from .compat import json
-from .compat import text_type
+
+from .compat import json, text_type
 
 
 class JSONFormatter(logging.Formatter):

--- a/python_logging_rabbitmq/handlers.py
+++ b/python_logging_rabbitmq/handlers.py
@@ -13,12 +13,13 @@ class RabbitMQHandler(logging.Handler):
     Python/Django logging handler to ship logs to RabbitMQ.
     Inspired by: https://github.com/ziXiong/MQHandler
     """
-    def __init__(self, level=logging.NOTSET, formatter=JSONFormatter(),
+    def __init__(self, level=logging.NOTSET, formatter=None,
                  host='localhost', port=5672, connection_params=None,
                  username=None, password=None,
                  exchange='log', declare_exchange=False,
                  routing_key_format="{name}.{level}", close_after_emit=False,
-                 fields=None, fields_under_root=True, message_headers=None):
+                 fields=None, fields_under_root=True, message_headers=None,
+                 record_fields=None, exclude_record_fields=None):
         # Initialize the handler.
         #
         # :param level:              Logs level.
@@ -59,7 +60,10 @@ class RabbitMQHandler(logging.Handler):
         self.message_headers = message_headers
 
         # Logging.
-        self.formatter = formatter
+        self.formatter = formatter or JSONFormatter(
+            include=record_fields,
+            exclude=exclude_record_fields
+        )
         self.fields = fields if isinstance(fields, dict) else {}
         self.fields_under_root = fields_under_root
 

--- a/python_logging_rabbitmq/handlers.py
+++ b/python_logging_rabbitmq/handlers.py
@@ -13,32 +13,28 @@ class RabbitMQHandler(logging.Handler):
     Python/Django logging handler to ship logs to RabbitMQ.
     Inspired by: https://github.com/ziXiong/MQHandler
     """
-
     def __init__(self, level=logging.NOTSET, formatter=JSONFormatter(),
                  host='localhost', port=5672, connection_params=None,
                  username=None, password=None,
                  exchange='log', declare_exchange=False,
                  routing_key_format="{name}.{level}", close_after_emit=False,
                  fields=None, fields_under_root=True, message_headers=None):
-        """
-        Initialize the handler.
-
-        :param level:              Logs level.
-        :param formatter:          Use custom formatter for the logs.
-        :param host:               RabbitMQ host. Default localhost
-        :param port:               RabbitMQ Port. Default 5672
-        :param connection_params:  Allow extra params to connect with RabbitMQ.
-        :param message_headers:    A dictionary of headers to be published with the message. Optional.
-        :param username:           Username in case of authentication.
-        :param password:           Password for the username.
-        :param exchange:           Send logs using this exchange.
-        :param declare_exchange:   Whether or not to declare the exchange.
-        :param routing_key_format: Customize how messages will be routed to the queues.
-        :param close_after_emit:   Close connection after emit the record?
-        :param fields:             Send these fields as part of all logs.
-        :param fields_under_root:  Merge the fields in the root object.
-        """
-
+        # Initialize the handler.
+        #
+        # :param level:              Logs level.
+        # :param formatter:          Use custom formatter for the logs.
+        # :param host:               RabbitMQ host. Default localhost
+        # :param port:               RabbitMQ Port. Default 5672
+        # :param connection_params:  Allow extra params to connect with RabbitMQ.
+        # :param message_headers:    A dictionary of headers to be published with the message. Optional.
+        # :param username:           Username in case of authentication.
+        # :param password:           Password for the username.
+        # :param exchange:           Send logs using this exchange.
+        # :param declare_exchange:   Whether or not to declare the exchange.
+        # :param routing_key_format: Customize how messages will be routed to the queues.
+        # :param close_after_emit:   Close connection after emit the record?
+        # :param fields:             Send these fields as part of all logs.
+        # :param fields_under_root:  Merge the fields in the root object.
         super(RabbitMQHandler, self).__init__(level=level)
 
         # Important instances/properties.
@@ -77,7 +73,6 @@ class RabbitMQHandler(logging.Handler):
         """
         Connect to RabbitMQ.
         """
-
         # Set logger for pika.
         # See if something went wrong connecting to RabbitMQ.
         handler = logging.StreamHandler()
@@ -104,7 +99,6 @@ class RabbitMQHandler(logging.Handler):
         """
         Close active connection.
         """
-
         if self.channel:
             self.channel.close()
 
@@ -145,7 +139,6 @@ class RabbitMQHandler(logging.Handler):
         """
         Free resources.
         """
-
         self.acquire()
 
         try:
@@ -157,5 +150,4 @@ class RabbitMQHandler(logging.Handler):
         """
         Close when destroy de instance.
         """
-
         self.close()

--- a/python_logging_rabbitmq/handlers.py
+++ b/python_logging_rabbitmq/handlers.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 import logging
+
 import pika
 from pika import credentials
-from .formatters import JSONFormatter
+
 from .filters import FieldFilter
+from .formatters import JSONFormatter
 
 
 class RabbitMQHandler(logging.Handler):

--- a/python_logging_rabbitmq/handlers_oneway.py
+++ b/python_logging_rabbitmq/handlers_oneway.py
@@ -15,32 +15,28 @@ class RabbitMQHandlerOneWay(logging.Handler):
     Python/Django logging handler to ship logs to RabbitMQ.
     Inspired by: https://github.com/ziXiong/MQHandler
     """
-
     def __init__(self, level=logging.NOTSET, formatter=JSONFormatter(),
                  host='localhost', port=5672, connection_params=None,
                  username=None, password=None,
                  exchange='log', declare_exchange=False,
                  routing_key_format="{name}.{level}", close_after_emit=False,
                  fields=None, fields_under_root=True, message_headers=None):
-        """
-        Initialize the handler.
-
-        :param level:              Logs level.
-        :param formatter:          Use custom formatter for the logs.
-        :param host:               RabbitMQ host. Default localhost
-        :param port:               RabbitMQ Port. Default 5672
-        :param connection_params:  Allow extra params to connect with RabbitMQ.
-        :param message_headers:    A dictionary of headers to be published with the message. Optional.
-        :param username:           Username in case of authentication.
-        :param password:           Password for the username.
-        :param exchange:           Send logs using this exchange.
-        :param declare_exchange:   Whether or not to declare the exchange.
-        :param routing_key_format: Customize how messages will be routed to the queues.
-        :param close_after_emit:   Close connection after emit the record?
-        :param fields:             Send these fields as part of all logs.
-        :param fields_under_root:  Merge the fields in the root object.
-        """
-
+        # Initialize the handler.
+        #
+        # :param level:              Logs level.
+        # :param formatter:          Use custom formatter for the logs.
+        # :param host:               RabbitMQ host. Default localhost
+        # :param port:               RabbitMQ Port. Default 5672
+        # :param connection_params:  Allow extra params to connect with RabbitMQ.
+        # :param message_headers:    A dictionary of headers to be published with the message. Optional.
+        # :param username:           Username in case of authentication.
+        # :param password:           Password for the username.
+        # :param exchange:           Send logs using this exchange.
+        # :param declare_exchange:   Whether or not to declare the exchange.
+        # :param routing_key_format: Customize how messages will be routed to the queues.
+        # :param close_after_emit:   Close connection after emit the record?
+        # :param fields:             Send these fields as part of all logs.
+        # :param fields_under_root:  Merge the fields in the root object.
         super(RabbitMQHandlerOneWay, self).__init__(level=level)
 
         # Important instances/properties.
@@ -83,7 +79,6 @@ class RabbitMQHandlerOneWay(logging.Handler):
         """
         Connect to RabbitMQ.
         """
-
         # Set logger for pika.
         # See if something went wrong connecting to RabbitMQ.
         if not self.connection or self.connection.is_closed or not self.channel or self.channel.is_closed:
@@ -112,7 +107,6 @@ class RabbitMQHandlerOneWay(logging.Handler):
         """
         Close active connection.
         """
-
         if self.channel:
             self.channel.close()
 
@@ -163,7 +157,6 @@ class RabbitMQHandlerOneWay(logging.Handler):
         """
         Free resources.
         """
-
         self.acquire()
 
         try:

--- a/python_logging_rabbitmq/handlers_oneway.py
+++ b/python_logging_rabbitmq/handlers_oneway.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 import logging
 import threading
-from .compat import Queue
 
 import pika
 from pika import credentials
 
+from .compat import Queue
 from .filters import FieldFilter
 from .formatters import JSONFormatter
 


### PR DESCRIPTION
Adds 'record_fields' and 'exclude_record_fields' to default handlers, as
well as 'include' and 'exclude' parameters to default JSON formatter
which allow to filter-out unwanted fields from output message, such as
"levelno" or "pathname".